### PR TITLE
Add use_proxy feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,60 @@
+# Xtesting Ansible Role
+
+Xtesting have leveraged on Functest efforts to provide a reference testing framework. To learn more about Xtesting: http://xtesting.readthedocs.io/en/latest/
+
+
+# Variables
+
+- `prefix`: (default `/data`) Base directory for the persistent storage of the containers (Jenkins, Mongo, etc.)
+- `use_proxy`: (default: `false`) When true, uses a proxy for those tasks that require Internet connectivity. Requires to set also `http_proxy` and `https_proxy`.
+
+
+## Site.yml example:
+
+```
+---
+- hosts: all
+  roles:
+    - role: ../ansible-role-xtesting
+      project: weather
+      repo: 127.0.0.1
+      dport: 5000
+      gerrit:
+      suites:
+        - container: weather
+          tests:
+            - humidity
+            - pressure
+            - temp
+            - half
+      jenkins_deploy: true
+      jenkins_configure: true
+      minio_deploy: true
+      radosgw_deploy: false
+      mongo_deploy: true
+      testapi_deploy: true
+      testapi_configure: true
+      registry_deploy: true
+      postgres_deploy: true
+      cachet_deploy: true
+      cachet_configure: true
+```
+
+## Inventory file example:
+
+```yaml
+---
+xtesting:
+  hosts:
+    127.0.0.1:
+      ansible_user: xtesting
+      ansible_python_interpreter: auto
+  vars:
+    http_proxy: http://10.113.55.36:8080
+    https_proxy: http://10.113.55.36:8080
+    use_proxy: true
+```
+
+# TO-DO:
+- Don't escalate privileges for Docker tasks
+

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,6 +8,7 @@ project: xtesting
 db_project: "{{ project }}"
 use_slave:  # true if slaves are deployed
 user_mail: root@localhost
+use_proxy: false
 
 # testcases
 repo: opnfv

--- a/tasks/cachet.yml
+++ b/tasks/cachet.yml
@@ -9,6 +9,11 @@
   delay: 10
   when:
     - cachet_deploy
+  environment:
+    use_proxy: "{{ use_proxy }}"
+    http_proxy: "{{ http_proxy if use_proxy else '' }}"
+    https_proxy: "{{ https_proxy if use_proxy else '' }}"
+
 - name: Starting Cachet
   become: true
   docker_container:

--- a/tasks/docker.yml
+++ b/tasks/docker.yml
@@ -8,5 +8,5 @@
   retries: 5
   delay: 10
   environment:
-    http_proxy: {{ http_proxy }}
-    https_proxy: {{ https_proxy }}
+    http_proxy: "{{ http_proxy }}"
+    https_proxy: "{{ https_proxy }}"

--- a/tasks/docker.yml
+++ b/tasks/docker.yml
@@ -35,7 +35,7 @@
     path: /etc/systemd/system/docker.service.d/http-proxy.conf
     section: Service
     option: Environment
-    value: "\"HTTP_PROXY={{ http_proxy}}\""
+    value: "\"HTTP_PROXY={{ http_proxy }}\""
     mode: '0600'
   when:
     - ansible_facts.services['docker.service'].source == "systemd"
@@ -47,7 +47,7 @@
     path: /etc/systemd/system/docker.service.d/https-proxy.conf
     section: Service
     option: Environment
-    value: "\"HTTPS_PROXY={{ https_proxy}}\""
+    value: "\"HTTPS_PROXY={{ https_proxy }}\""
     mode: '0600'
   when:
     - ansible_facts.services['docker.service'].source == "systemd"

--- a/tasks/docker.yml
+++ b/tasks/docker.yml
@@ -29,7 +29,7 @@
     - docker
     append: yes
 
-- name: Configure proxy on docker (1/2)
+- name: Configure proxy on docker (1/3)
   become: yes
   community.general.ini_file:
     path: /etc/systemd/system/docker.service.d/http-proxy.conf
@@ -41,7 +41,7 @@
     - ansible_facts.services['docker.service'].source == "systemd"
     - use_proxy
 
-- name: Configure proxy on docker (2/2)
+- name: Configure proxy on docker (2/3)
   become: yes
   community.general.ini_file:
     path: /etc/systemd/system/docker.service.d/https-proxy.conf
@@ -49,6 +49,16 @@
     option: Environment
     value: "\"HTTPS_PROXY={{ https_proxy}}\""
     mode: '0600'
+  when:
+    - ansible_facts.services['docker.service'].source == "systemd"
+    - use_proxy
+
+- name: Configure proxy on docker (3/3)
+  become: yes
+  systemd:
+    name: docker
+    daemon_reload: yes
+    state: restarted
   when:
     - ansible_facts.services['docker.service'].source == "systemd"
     - use_proxy

--- a/tasks/docker.yml
+++ b/tasks/docker.yml
@@ -58,7 +58,16 @@
   systemd:
     name: docker
     daemon_reload: yes
-    state: restarted
+    state: reloaded
   when:
     - ansible_facts.services['docker.service'].source == "systemd"
     - use_proxy
+
+- name: Ensure docker service is running
+  become: yes
+  systemd:
+    name: docker
+    daemon_reload: yes
+    state: started
+  when:
+    - ansible_facts.services['docker.service'].source == "systemd"

--- a/tasks/docker.yml
+++ b/tasks/docker.yml
@@ -8,5 +8,33 @@
   retries: 5
   delay: 10
   environment:
-    http_proxy: "{{ http_proxy }}"
-    https_proxy: "{{ https_proxy }}"
+    use_proxy: "{{ use_proxy }}"
+    http_proxy: "{{ http_proxy if use_proxy else '' }}"
+    https_proxy: "{{ https_proxy if use_proxy else '' }}"
+
+- name: populate service ansible_facts
+  service_facts:
+
+- name: Configure proxy on docker (1/2)
+  become: yes
+  community.general.ini_file:
+    path: /etc/systemd/system/docker.service.d/http-proxy.conf
+    section: Service
+    option: Environment
+    value: "\"HTTP_PROXY={{ http_proxy}}\""
+    mode: '0600'
+  when:
+    - ansible_facts.services['docker.service'].source == "systemd"
+    - use_proxy
+
+- name: Configure proxy on docker (2/2)
+  become: yes
+  community.general.ini_file:
+    path: /etc/systemd/system/docker.service.d/https-proxy.conf
+    section: Service
+    option: Environment
+    value: "\"HTTPS_PROXY={{ https_proxy}}\""
+    mode: '0600'
+  when:
+    - ansible_facts.services['docker.service'].source == "systemd"
+    - use_proxy

--- a/tasks/docker.yml
+++ b/tasks/docker.yml
@@ -7,3 +7,6 @@
   until: my_result is succeeded
   retries: 5
   delay: 10
+  environment:
+    http_proxy: {{ http_proxy }}
+    https_proxy: {{ https_proxy }}

--- a/tasks/docker.yml
+++ b/tasks/docker.yml
@@ -15,6 +15,20 @@
 - name: populate service ansible_facts
   service_facts:
 
+- name: Ensure group "docker" exists
+  become: yes
+  group:
+    name: docker
+    state: present
+
+- name: Add user to docker group
+  become: yes
+  user:
+    name: "{{ ansible_ssh_user }}"
+    groups:
+    - docker
+    append: yes
+
 - name: Configure proxy on docker (1/2)
   become: yes
   community.general.ini_file:

--- a/tasks/jenkins.yml
+++ b/tasks/jenkins.yml
@@ -27,6 +27,9 @@
       - /var/run/docker.sock:/var/run/docker.sock
       - '{{ prefix }}/jenkins:/var/jenkins_home'
   register: docker_response
+  environment:
+    http_proxy: "{{ http_proxy }}"
+    https_proxy: "{{ https_proxy }}"
   when:
     - jenkins_deploy
 - name: Waiting Jenkins

--- a/tasks/jenkins.yml
+++ b/tasks/jenkins.yml
@@ -12,12 +12,12 @@
   environment:
     http_proxy: "{{ http_proxy }}"
     https_proxy: "{{ https_proxy }}"
-- name: Starting Jenkins (fer)
+- name: Starting Jenkins
   become: true
   docker_container:
     name: jenkins
     image: ollivier/xtesting-jenkins
-    pull: '{{ docker_pull }}'
+    # pull: '{{ docker_pull }}'
     recreate: '{{ docker_recreate }}'
     restart_policy: '{{ docker_restart_policy }}'
     published_ports:

--- a/tasks/jenkins.yml
+++ b/tasks/jenkins.yml
@@ -10,8 +10,10 @@
   when:
     - jenkins_deploy or jenkins_configure
   environment:
-    http_proxy: "{{ http_proxy }}"
-    https_proxy: "{{ https_proxy }}"
+    use_proxy: "{{ use_proxy }}"
+    http_proxy: "{{ http_proxy if use_proxy else '' }}"
+    https_proxy: "{{ https_proxy if use_proxy else '' }}"
+
 - name: Starting Jenkins
   become: true
   docker_container:
@@ -26,17 +28,20 @@
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - '{{ prefix }}/jenkins:/var/jenkins_home'
-  register: docker_response
   environment:
-    http_proxy: "{{ http_proxy }}"
-    https_proxy: "{{ https_proxy }}"
+    use_proxy: "{{ use_proxy }}"
+    http_proxy: "{{ http_proxy if use_proxy else '' }}"
+    https_proxy: "{{ https_proxy if use_proxy else '' }}"
+  register: docker_response
   when:
     - jenkins_deploy
+
 - name: Waiting Jenkins
   pause:
     seconds: '{{ jenkins_wait }}'
   when:
     - docker_response.changed
+
 - name: Creating jenkins_jobs.ini
   template:
     src: jenkins_jobs.ini.j2
@@ -44,6 +49,7 @@
     mode: '0644'
   when:
     - jenkins_configure
+
 - name: Creating {{ project }}.yaml
   template:
     src: run.yaml.j2
@@ -51,6 +57,7 @@
     mode: '0644'
   when:
     - jenkins_create_jobs
+
 - name: Loading Jenkins jobs
   command: |
     jenkins-jobs --conf \

--- a/tasks/jenkins.yml
+++ b/tasks/jenkins.yml
@@ -9,7 +9,10 @@
   delay: 10
   when:
     - jenkins_deploy or jenkins_configure
-- name: Starting Jenkins
+  environment:
+    http_proxy: "{{ http_proxy }}"
+    https_proxy: "{{ https_proxy }}"
+- name: Starting Jenkins (fer)
   become: true
   docker_container:
     name: jenkins

--- a/tasks/jenkins.yml
+++ b/tasks/jenkins.yml
@@ -64,6 +64,8 @@
       {{ tmp_dir }}/jenkins_jobs.ini update {{ tmp_dir }}/{{ project }}.yaml
   register: exit_code
   changed_when: exit_code.rc == 0
+  environment:
+    no_proxy: "{{ ipaddress }}"
   when:
     - jenkins_configure
     - jenkins_create_jobs

--- a/tasks/testapi.yml
+++ b/tasks/testapi.yml
@@ -15,10 +15,12 @@
       auth: 'false'
   register: docker_response
   environment:
-    http_proxy: "{{ http_proxy }}"
-    https_proxy: "{{ https_proxy }}"
+    use_proxy: "{{ use_proxy }}"
+    http_proxy: "{{ http_proxy if use_proxy else '' }}"
+    https_proxy: "{{ https_proxy if use_proxy else '' }}"
   when:
     - testapi_deploy
+
 - name: Waiting TestAPI
   pause:
     seconds: '{{ testapi_wait }}'

--- a/tasks/testapi.yml
+++ b/tasks/testapi.yml
@@ -14,6 +14,9 @@
       mongodb_url: '{{ mongo_url }}'
       auth: 'false'
   register: docker_response
+  environment:
+    http_proxy: "{{ http_proxy }}"
+    https_proxy: "{{ https_proxy }}"
   when:
     - testapi_deploy
 - name: Waiting TestAPI

--- a/tasks/testapi.yml
+++ b/tasks/testapi.yml
@@ -30,6 +30,7 @@
     status_code:
       - 200
       - 404
+    use_proxy: no
   register: http_response
   when:
     - testapi_deploy or testapi_configure
@@ -40,6 +41,7 @@
     body: {"name":"{{ project }}"}
     status_code: 200
     body_format: json
+    use_proxy: no
   when:
     - testapi_deploy or testapi_configure
     - http_response.status != 200
@@ -49,6 +51,7 @@
     status_code:
       - 200
       - 404
+    use_proxy: no
   register: http_response
   when:
     - testapi_deploy or testapi_configure
@@ -68,6 +71,7 @@
     status_code:
       - 200
       - 404
+    use_proxy: no
   with_subelements:
     - '{{ suites }}'
     - 'tests'
@@ -81,6 +85,7 @@
     body: {"name":"{{ item.item.1 }}"}
     status_code: 200
     body_format: json
+    use_proxy: no
   with_items:
     - '{{ http_response.results }}'
   loop_control:


### PR DESCRIPTION
Now, the module can be used inside a network that requires an HTTP proxy to access the Internet.
Just define `use_proxy` to `true` and configure `http_proxy` and `https_proxy` vars accordingly in the inventory file or in the playbook that makes use of this module.

e.g. in the inventory.yml file would be:
```yaml
xtesting:
  hosts:
    127.0.0.1:
      ansible_user: xtesting
      ansible_python_interpreter: auto
  vars:
    http_proxy: http://192.168.1.100:8080
    https_proxy: http://192.168.1.100:8080
    use_proxy: true
```